### PR TITLE
Search bar focus, Use it, and other changes

### DIFF
--- a/conanio/.env.development
+++ b/conanio/.env.development
@@ -1,1 +1,3 @@
 CONANIO_SERVER=http://127.0.0.1:4000
+GTM_ID=DEVELOP
+GTM_URL=my.fake.url

--- a/conanio/.env.development
+++ b/conanio/.env.development
@@ -1,3 +1,3 @@
 CONANIO_SERVER=http://127.0.0.1:4000
 GTM_ID=DEVELOP
-GTM_URL=my.fake.url
+GTM_URL=http://0.0.0.0.fake:4000

--- a/conanio/.env.production
+++ b/conanio/.env.production
@@ -1,1 +1,3 @@
 CONANIO_SERVER=http://conanio-server:5000
+GTM_ID=GTM-WK44ZFM
+GTM_URL=https://www.googletagmanager.com/gtm.js

--- a/conanio/components/footer.js
+++ b/conanio/components/footer.js
@@ -1,6 +1,5 @@
 import { useState } from "react";
-import Link from 'next/link'
-import Script from 'next/script'
+import Link from 'next/link';
 import MarketoForm from "./useMarketo";
 
 

--- a/conanio/components/header.js
+++ b/conanio/components/header.js
@@ -1,8 +1,6 @@
 import Head from 'next/head';
 import Link from 'next/link';
-import Script from 'next/script';
 import { useRouter } from "next/router";
-
 import Nav from 'react-bootstrap/Nav';
 import Navbar from 'react-bootstrap/Navbar';
 import { LuPackageSearch } from "react-icons/lu";

--- a/conanio/components/home.js
+++ b/conanio/components/home.js
@@ -1,4 +1,4 @@
-import Link from 'next/link'
+import Link from 'next/link';
 import Slider from 'react-slick';
 
 

--- a/conanio/components/loader.js
+++ b/conanio/components/loader.js
@@ -1,8 +1,6 @@
 import React from 'react';
 import { SSRProvider } from 'react-bootstrap';
 import { ConanCenterHeader } from './header';
-import ConanFooter from './footer';
-import Container from 'react-bootstrap/Container';
 
 
 // From: https://stackabuse.com/how-to-create-a-loading-animation-in-react-from-scratch/

--- a/conanio/components/loader.js
+++ b/conanio/components/loader.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { SSRProvider } from 'react-bootstrap';
+
 import { ConanCenterHeader } from './header';
 
 
@@ -8,14 +8,14 @@ import { ConanCenterHeader } from './header';
 export default function Loader() {
   return (
     <React.StrictMode>
-      <SSRProvider>
+
       <div className="flex-wrapper">
         <ConanCenterHeader/>
           <div className="loader-container">
             <div className="spinner"></div>
           </div>
       </div>
-      </SSRProvider>
+
     </React.StrictMode>
   );
 }

--- a/conanio/components/recipeTabs.js
+++ b/conanio/components/recipeTabs.js
@@ -116,7 +116,6 @@ function CCIAssistanceLink() {
 
 function UseItFullContent({props}) {
   const reference = props.recipeName + "/" + props.recipeVersion;
-  const [conanfile, setConanfile] = useState('txt');
 
   const TargetsInfo = function(recipe_properties) {
     const [open, setOpen] = useState(false);
@@ -223,29 +222,16 @@ target_link_libraries(YOUR_TARGET ${cmakeTargetName.split(" (config),")[0].trim(
     return null;
   };
 
-  return (
-    <div>
-      <h3>Using {props.recipeName}</h3>
-      <blockquote>
-        <BiSolidInfoCircle/><strong> Note</strong>
-        <br/><br/>
-        If you are new with Conan, we recommend to read the section <Link href="https://docs.conan.io/2/tutorial/consuming_packages.html"><a>how to consume packages</a></Link>.
-        <CCIAssistanceLink />
-      </blockquote>
-      Simplest use case consuming this recipe and assuming CMake as your local build tool:
-      <br/><br/>
-      <Tabs
-        id="conanfile-tab-selection"
-        activeKey={conanfile}
-        onSelect={(k) => setConanfile(k)}
-        className="mb-3"
-      >
-        <Tab eventKey="txt" title={<span><BsFiletypeTxt className="conanIcon18 mr-1"/> conanfile.txt</span>}>
-          <pre><code className="language-ini">{"[requires]\n" + reference + "\n" + "[generators]\n" + "CMakeDeps\n" + "CMakeToolchain\n" + "[layout]\ncmake_layout"}</code></pre>
-        </Tab>
-        <Tab eventKey="py" title={<span><FaPython className="conanIcon18 mr-1"/> conanfile.py</span>}>
-          <pre><code className="language-python">
-            {`from conan import ConanFile
+  const ConanfileInfo = function() {
+    const [conanfile, setConanfile] = useState('txt');
+    const conanfileTxt = `[requires]
+${reference}
+[generators]
+CMakeDeps
+CMakeToolchain
+[layout]
+cmake_layout`;
+    const conanfilePy = `from conan import ConanFile
 from conan.tools.cmake import cmake_layout
 
 
@@ -257,13 +243,38 @@ class ExampleRecipe(ConanFile):
         self.requires("${reference}")
 
     def layout(self):
-        cmake_layout(self)`}</code></pre>
-        </Tab>
+        cmake_layout(self)`;
+      return (
+        <>
+          <Tabs id="conanfile-tab-selection" activeKey={conanfile} onSelect={(k) => setConanfile(k)} className="package-tabs">
+            <Tab eventKey="txt" title={<span><BsFiletypeTxt className="conanIcon18 mr-1"/> conanfile.txt</span>}>
+              <ClipboardCopy copyText={conanfileTxt}/>
+              <pre><code className="language-ini">{conanfileTxt}</code></pre>
+            </Tab>
+            <Tab eventKey="py" title={<span><FaPython className="conanIcon18 mr-1"/> conanfile.py</span>}>
+              <ClipboardCopy copyText={conanfilePy}/>
+              <pre><code className="language-python">{conanfilePy}</code></pre>
+            </Tab>
+          </Tabs>
+          <br/>
+          <p>Now, you can run this Conan command to locally install (and build if necessary) this recipe and its dependencies (if any):</p>
+          <pre><code className="language-bash">{`$ conan install conanfile.${conanfile} --build=missing`}</code></pre>
+        </>
+      );
+  };
 
-      </Tabs>
-      <br/>
-      <p>Now, you can run this Conan command to locally install (and build if necessary) this recipe and its dependencies (if any):</p>
-      <pre><code className="language-bash">{`$ conan install conanfile.${conanfile} --build=missing`}</code></pre>
+  return (
+    <div>
+      <h3>Using {props.recipeName}</h3>
+      <blockquote>
+        <BiSolidInfoCircle/><strong> Note</strong>
+        <br/><br/>
+        If you are new with Conan, we recommend to read the section <Link href="https://docs.conan.io/2/tutorial/consuming_packages.html"><a>how to consume packages</a></Link>.
+        <CCIAssistanceLink />
+      </blockquote>
+      Simplest use case consuming this recipe and assuming CMake as your local build tool:
+      <br/><br/>
+      <ConanfileInfo />
       <RecipeDetails />
       <br/>
     </div>

--- a/conanio/components/recipeTabs.js
+++ b/conanio/components/recipeTabs.js
@@ -19,7 +19,6 @@ import {
 } from "react-icons/ai";
 import { TfiMoreAlt } from "react-icons/tfi";
 import { FaTags, FaWindows, FaLinux, FaApple } from "react-icons/fa";
-import { SiConan } from "react-icons/si";
 import ListGroup from 'react-bootstrap/ListGroup';
 import { Tooltip as ReactTooltip } from 'react-tooltip';
 import ButtonGroup from 'react-bootstrap/ButtonGroup';

--- a/conanio/components/recipeTabs.js
+++ b/conanio/components/recipeTabs.js
@@ -235,21 +235,35 @@ target_link_libraries(YOUR_TARGET ${cmakeTargetName.split(" (config),")[0].trim(
       Simplest use case consuming this recipe and assuming CMake as your local build tool:
       <br/><br/>
       <Tabs
-        id="controlled-tab-example"
+        id="conanfile-tab-selection"
         activeKey={conanfile}
         onSelect={(k) => setConanfile(k)}
         className="mb-3"
       >
         <Tab eventKey="txt" title={<span><BsFiletypeTxt className="conanIcon18 mr-1"/> conanfile.txt</span>}>
-        <pre><code className="language-ini">{"[requires]\n" + reference + "\n" + "[generators]\n" + "CMakeDeps\n" + "CMakeToolchain\n" + "[layout]\ncmake_layout"}</code></pre>
+          <pre><code className="language-ini">{"[requires]\n" + reference + "\n" + "[generators]\n" + "CMakeDeps\n" + "CMakeToolchain\n" + "[layout]\ncmake_layout"}</code></pre>
         </Tab>
         <Tab eventKey="py" title={<span><FaPython className="conanIcon18 mr-1"/> conanfile.py</span>}>
-          <pre><code className="language-python">{"from conan import ConanFile"}</code></pre>
+          <pre><code className="language-python">
+            {`from conan import ConanFile
+from conan.tools.cmake import cmake_layout
+
+
+class ExampleRecipe(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "CMakeDeps", "CMakeToolchain"
+
+    def requirements(self):
+        self.requires("${reference}")
+
+    def layout(self):
+        cmake_layout(self)`}</code></pre>
         </Tab>
+
       </Tabs>
       <br/>
       <p>Now, you can run this Conan command to locally install (and build if necessary) this recipe and its dependencies (if any):</p>
-      <pre><code className="language-bash">$ conan install conanfile.{conanfile} --build=missing</code></pre>
+      <pre><code className="language-bash">{`$ conan install conanfile.${conanfile} --build=missing`}</code></pre>
       <RecipeDetails />
       <br/>
     </div>

--- a/conanio/components/recipeTabs.js
+++ b/conanio/components/recipeTabs.js
@@ -18,6 +18,8 @@ import {
   AiOutlineMinusCircle
 } from "react-icons/ai";
 import { TfiMoreAlt } from "react-icons/tfi";
+import { FaPython } from "react-icons/fa";
+import { BsFiletypeTxt } from "react-icons/bs";
 import { FaTags, FaWindows, FaLinux, FaApple } from "react-icons/fa";
 import ListGroup from 'react-bootstrap/ListGroup';
 import { Tooltip as ReactTooltip } from 'react-tooltip';
@@ -114,6 +116,7 @@ function CCIAssistanceLink() {
 
 function UseItFullContent({props}) {
   const reference = props.recipeName + "/" + props.recipeVersion;
+  const [conanfile, setConanfile] = useState('txt');
 
   const TargetsInfo = function(recipe_properties) {
     const [open, setOpen] = useState(false);
@@ -231,10 +234,22 @@ target_link_libraries(YOUR_TARGET ${cmakeTargetName.split(" (config),")[0].trim(
       </blockquote>
       Simplest use case consuming this recipe and assuming CMake as your local build tool:
       <br/><br/>
-      <h4>conanfile.txt</h4>
-      <pre><code className="language-ini">{"[requires]\n" + reference + "\n" + "[generators]\n" + "CMakeDeps\n" + "CMakeToolchain\n" + "[layout]\ncmake_layout"}</code></pre>
+      <Tabs
+        id="controlled-tab-example"
+        activeKey={conanfile}
+        onSelect={(k) => setConanfile(k)}
+        className="mb-3"
+      >
+        <Tab eventKey="txt" title={<span><BsFiletypeTxt className="conanIcon18 mr-1"/> conanfile.txt</span>}>
+        <pre><code className="language-ini">{"[requires]\n" + reference + "\n" + "[generators]\n" + "CMakeDeps\n" + "CMakeToolchain\n" + "[layout]\ncmake_layout"}</code></pre>
+        </Tab>
+        <Tab eventKey="py" title={<span><FaPython className="conanIcon18 mr-1"/> conanfile.py</span>}>
+          <pre><code className="language-python">{"from conan import ConanFile"}</code></pre>
+        </Tab>
+      </Tabs>
+      <br/>
       <p>Now, you can run this Conan command to locally install (and build if necessary) this recipe and its dependencies (if any):</p>
-      <pre><code className="language-bash">$ conan install conanfile.txt --build=missing</code></pre>
+      <pre><code className="language-bash">$ conan install conanfile.{conanfile} --build=missing</code></pre>
       <RecipeDetails />
       <br/>
     </div>

--- a/conanio/components/searchbar.js
+++ b/conanio/components/searchbar.js
@@ -1,11 +1,9 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import Row from 'react-bootstrap/Row';
 import Col from 'react-bootstrap/Col';
 import Form from 'react-bootstrap/Form';
-import FormCheck from 'react-bootstrap/FormCheck';
 import Button from 'react-bootstrap/Button';
 import InputGroup from 'react-bootstrap/InputGroup';
-import ButtonGroup from 'react-bootstrap/ButtonGroup';
 import Select from "react-select";
 import { LuPackageSearch } from "react-icons/lu";
 import { BiPackage } from "react-icons/bi";
@@ -158,11 +156,16 @@ export function ConanMultiSelectFilter(props) {
 }
 
 export function ConanSearchBar(props) {
+  const inputRef = useRef(null);
+
+  useEffect(() => {
+    inputRef.current.focus();
+  }, []);
   return (
     <Col>
       <Row className="justify-content-md-center">
         <InputGroup>
-          <Form.Control className="searchbarConan" type="text" placeholder="Search..." value={props.value} onChange={(e) => props.handleChange(e.target.value)}/>
+          <Form.Control ref={inputRef} className="searchbarConan" type="text" placeholder="Search..." value={props.value} onChange={(e) => props.handleChange(e.target.value)}/>
           <Button className="searchButtonConan" type="submit">
             <LuPackageSearch className="conanLogo"/>
           </Button>

--- a/conanio/components/user-story.js
+++ b/conanio/components/user-story.js
@@ -1,4 +1,4 @@
-import Link from 'next/link'
+import Link from 'next/link';
 
 export default function SingleUserStory(props) {
   return (

--- a/conanio/next.config.js
+++ b/conanio/next.config.js
@@ -6,6 +6,8 @@ const nextConfig = {
   },
   env: {
     conanioServer: process.env.CONANIO_SERVER,
+    gtmURL: process.env.GTM_URL,
+    gtmID: process.env.GTM_ID
   },
   async redirects() {
     return [

--- a/conanio/pages/_app.js
+++ b/conanio/pages/_app.js
@@ -17,9 +17,10 @@ import Loader from '../components/loader';
 
 
 export default function  MyApp({ Component, pageProps }){
-  const router = useRouter()
-  const [loading, setLoading] = React.useState(false)
-  const GTM_ID = 'GTM-WK44ZFM'
+  const router = useRouter();
+  const [loading, setLoading] = React.useState(false);
+  const GTM_ID = process.env.gtmID;
+  const GTM_URL = process.env.gtmURL;
   React.useEffect(() => {
     const handleRouteChange = (url) => {setLoading(true)}
     const handleRouteChangeComplete = () => {setLoading(false)}
@@ -32,7 +33,6 @@ export default function  MyApp({ Component, pageProps }){
       router.events.off('routeChangeComplete', handleRouteChangeComplete)
     }
   }, [router.events])
-
   return (
     <>
       <Script id="google-tag-manager" strategy="afterInteractive">
@@ -40,7 +40,7 @@ export default function  MyApp({ Component, pageProps }){
           (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
           new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
           j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-          'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+          '${GTM_URL}?id='+i+dl;f.parentNode.insertBefore(j,f);
           })(window,document,'script','dataLayer','${GTM_ID}');
         `}
       </Script>

--- a/conanio/pages/center.js
+++ b/conanio/pages/center.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { useState } from "react";
-import { SSRProvider } from 'react-bootstrap';
+
 import Container from 'react-bootstrap/Container';
 import Row from 'react-bootstrap/Row';
 import Col from 'react-bootstrap/Col';
@@ -68,7 +68,7 @@ function CenterList(props) {
 export default function Center(props) {
   return (
     <React.StrictMode>
-      <SSRProvider>
+
       <div className="flex-wrapper bg-conan-blue">
         <ConanCenterHeader/>
           <br/>
@@ -113,7 +113,7 @@ export default function Center(props) {
           <br/>
         <ConanFooter/>
       </div>
-      </SSRProvider>
+
     </React.StrictMode>
   )
 }

--- a/conanio/pages/center/recipes.js
+++ b/conanio/pages/center/recipes.js
@@ -7,20 +7,16 @@ import Row from 'react-bootstrap/Row';
 import Col from 'react-bootstrap/Col';
 import Form from 'react-bootstrap/Form';
 import Badge from 'react-bootstrap/Badge';
-import InputGroup from 'react-bootstrap/InputGroup';
 import { ConanSearchBar,
          ConanMultiSelectFilter,
          ConanSingleSelect } from "../../components/searchbar";
 import ListGroup from 'react-bootstrap/ListGroup';
-import Alert from 'react-bootstrap/Alert';
 import Link from 'next/link';
 import { ConanCenterHeader } from '../../components/header';
 import ConanFooter from '../../components/footer';
 import { prettyProfiles,
-         levenshteinDistance,
          DefaultDescription } from '../../components/utils';
-import { LiaBalanceScaleSolid, LiaGithub } from "react-icons/lia";
-import { IoMdDownload } from "react-icons/io";
+import { LiaBalanceScaleSolid } from "react-icons/lia";
 import { BsFilterCircleFill, BsFilterCircle } from "react-icons/bs";
 import { MdFilter1,
   MdFilter2,

--- a/conanio/pages/center/recipes.js
+++ b/conanio/pages/center/recipes.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useState, useEffect } from 'react';
 import { useRouter } from 'next/router';
-import { SSRProvider } from 'react-bootstrap';
+
 import Container from 'react-bootstrap/Container';
 import Row from 'react-bootstrap/Row';
 import Col from 'react-bootstrap/Col';
@@ -291,7 +291,7 @@ export default function ConanSearch(props) {
 
   return (
     <React.StrictMode>
-      <SSRProvider>
+
       <div className="flex-wrapper bg-conan-blue">
         <ConanCenterHeader titlePrefix={"Search Result"}/>
           <br/>
@@ -351,7 +351,7 @@ export default function ConanSearch(props) {
           <br/>
         <ConanFooter/>
       </div>
-      </SSRProvider>
+
     </React.StrictMode>
 
   );

--- a/conanio/pages/center/recipes/[recipeName].js
+++ b/conanio/pages/center/recipes/[recipeName].js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useState, useEffect } from "react";
 import { useRouter } from 'next/router';
-import { SSRProvider } from 'react-bootstrap';
+
 import Container from 'react-bootstrap/Container';
 import Row from 'react-bootstrap/Row';
 import Col from 'react-bootstrap/Col';
@@ -57,6 +57,7 @@ export default function ConanPackage(props) {
   useEffect(() => {
     hljs.highlightAll();
   });
+
   const [selectedVersion, setSelectedVersion] = useState(props.recipeVersion !== null? props.recipeVersion: props.data[0].info.version);
   const indexSelectedVersion = Object.keys(props.data).filter(index => props.data[index].info.version === selectedVersion)[0];
   const isBigScreen = useMediaQuery({ query: '(min-width: 1824px)' })
@@ -289,7 +290,7 @@ export default function ConanPackage(props) {
 
   return (
     <React.StrictMode>
-      <SSRProvider>
+
       <div className="flex-wrapper bg-conan-blue">
         <ConanCenterHeader titlePrefix={recipeData.name}/>
         <Container className="conancontainer">
@@ -347,7 +348,7 @@ export default function ConanPackage(props) {
         <br/>
         <ConanFooter/>
       </div>
-      </SSRProvider>
+
     </React.StrictMode>
   );
 }

--- a/conanio/pages/center/recipes/[recipeName].js
+++ b/conanio/pages/center/recipes/[recipeName].js
@@ -88,6 +88,9 @@ export default function ConanPackage(props) {
 
 
   function RecipeInfo() {
+    const isToolRequire = recipeUseIt && recipeUseIt.package_type == "application";
+    const fieldRequirements = isToolRequire? 'tool_requires': 'requires';
+
     return (
       <Col xs lg="3" className="pl-4 mt-4 pt-4">
         {recipeDescription && <Row xs lg className="mb-2"><Col xs lg><h5>Recipe info</h5></Col></Row>}
@@ -174,9 +177,9 @@ export default function ConanPackage(props) {
           <Col xs lg>
             Add the following line to your conanfile.txt:
             <pre>
-              <code style={{backgroundColor: "white"}} className="language-ini">{
-              "[requires]\n" +
-              recipeData.name + "/"+ selectedVersion + "\n"}
+              <code style={{backgroundColor: "white"}} className="language-ini">
+{`[${fieldRequirements}]
+${recipeData.name}/${selectedVersion}`}
               </code>
             </pre>
           </Col>

--- a/conanio/pages/center/recipes/[recipeName].js
+++ b/conanio/pages/center/recipes/[recipeName].js
@@ -5,17 +5,12 @@ import { SSRProvider } from 'react-bootstrap';
 import Container from 'react-bootstrap/Container';
 import Row from 'react-bootstrap/Row';
 import Col from 'react-bootstrap/Col';
-import Form from 'react-bootstrap/Form';
-import Tab from 'react-bootstrap/Tab';
-import Tabs from 'react-bootstrap/Tabs';
 import Badge from 'react-bootstrap/Badge';
 import ButtonGroup from 'react-bootstrap/ButtonGroup';
 import Button from 'react-bootstrap/Button';
-import Card from 'react-bootstrap/Card';
 import Link from 'next/link';
 import { ConanCenterHeader } from '../../../components/header';
 import { truncate,
-         truncateTooltip,
          truncateAdnCopy,
          sanitizeURL,
          ClipboardCopy,
@@ -24,7 +19,7 @@ import { truncate,
 import ConanFooter from '../../../components/footer';
 import { get_json, get_urls } from '../../../service/service';
 import { LiaBalanceScaleSolid, LiaGithub } from "react-icons/lia";
-import { IoMdHome, IoMdDownload } from "react-icons/io";
+import { IoMdHome } from "react-icons/io";
 import hljs from "highlight.js";
 import { UseItTab,
          BadgesTab,
@@ -33,12 +28,10 @@ import { UseItTab,
          StatsTab,
          PackagesTab } from "../../../components/recipeTabs";
 import { PiWarningBold } from "react-icons/pi";
-import { MdOutlineCheckCircleOutline, MdOutlineToday } from "react-icons/md";
-import { BiInfoCircle } from "react-icons/bi";
-import { AiOutlinePushpin, AiOutlineBarChart } from "react-icons/ai";
+import { MdOutlineToday } from "react-icons/md";
+import { AiOutlinePushpin } from "react-icons/ai";
 import { PiGraphDuotone, PiMedal } from "react-icons/pi";
 import { FaTags, FaHashtag } from "react-icons/fa";
-import { LuBinary } from "react-icons/lu";
 import { SiConan } from "react-icons/si";
 import { HiOutlineDocumentText } from "react-icons/hi";
 import { BasicSearchBar } from "../../../components/searchbar";

--- a/conanio/pages/downloads.js
+++ b/conanio/pages/downloads.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { SSRProvider } from 'react-bootstrap';
+
 import { ConanKitchenHeader } from '../components/header';
 import ConanFooter from '../components/footer';
 import { Tooltip } from 'react-tooltip';
@@ -379,7 +379,7 @@ function DownloadJFrogArtifactoryCommunityEditionForCpp() {
 function DownloadsPage() {
   return (
     <React.StrictMode>
-      <SSRProvider>
+
       <div className="flex-wrapper">
         <ConanKitchenHeader/>
         <section className="downloads-hero position-relative pb-5" id="downloadsHero">
@@ -420,7 +420,7 @@ function DownloadsPage() {
         </section>
         <ConanFooter/>
       </div>
-      </SSRProvider>
+
     </React.StrictMode>
   );
 }

--- a/conanio/pages/faq.js
+++ b/conanio/pages/faq.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import Link from 'next/link';
-import { SSRProvider } from 'react-bootstrap';
+
 import { ConanKitchenHeader } from '../components/header';
 import ConanFooter from '../components/footer';
 
@@ -83,7 +83,7 @@ function FaqPage() {
 
   return (
     <React.StrictMode>
-      <SSRProvider>
+
       <div className="flex-wrapper">
         <ConanKitchenHeader/>
           <section id="faqHero" className="position-relative sub-page-hero">
@@ -134,7 +134,7 @@ function FaqPage() {
 
         <ConanFooter/>
       </div>
-      </SSRProvider>
+
     </React.StrictMode>
   );
 }

--- a/conanio/pages/index.js
+++ b/conanio/pages/index.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { SSRProvider } from 'react-bootstrap';
+
 import { ConanKitchenHeader } from '../components/header';
 import ConanHome from '../components/home';
 import ConanFooter from '../components/footer';
@@ -7,13 +7,13 @@ import ConanFooter from '../components/footer';
 function HomePage() {
   return (
     <React.StrictMode>
-      <SSRProvider>
+
       <div className="flex-wrapper">
         <ConanKitchenHeader/>
         <ConanHome/>
         <ConanFooter/>
       </div>
-      </SSRProvider>
+
     </React.StrictMode>
   );
 }

--- a/conanio/pages/privacy-policy.js
+++ b/conanio/pages/privacy-policy.js
@@ -1,12 +1,12 @@
 import React from 'react';
-import { SSRProvider } from 'react-bootstrap';
+
 import { ConanKitchenHeader } from '../components/header';
 import ConanFooter from '../components/footer';
 
 function PrivacyPolicyPage() {
   return (
     <React.StrictMode>
-      <SSRProvider>
+
       <div className="flex-wrapper">
         <ConanKitchenHeader/>
         <section id="privacy-policy" className="py-5">
@@ -520,7 +520,7 @@ function PrivacyPolicyPage() {
         </section>
         <ConanFooter/>
       </div>
-      </SSRProvider>
+
     </React.StrictMode>
   );
 }

--- a/conanio/pages/terms-conditions.js
+++ b/conanio/pages/terms-conditions.js
@@ -1,12 +1,12 @@
 import React from 'react';
-import { SSRProvider } from 'react-bootstrap';
+
 import { ConanKitchenHeader } from '../components/header';
 import ConanFooter from '../components/footer';
 
 function TermsConditionPage() {
   return (
     <React.StrictMode>
-      <SSRProvider>
+
       <div className="flex-wrapper">
         <ConanKitchenHeader/>
         <section id="terms-and-conditions" className="py-5">
@@ -128,7 +128,7 @@ function TermsConditionPage() {
         </section>
         <ConanFooter/>
       </div>
-      </SSRProvider>
+
     </React.StrictMode>
   );
 }

--- a/conanio/pages/tribe.js
+++ b/conanio/pages/tribe.js
@@ -1,6 +1,6 @@
 import Link from 'next/link'
 import React from 'react';
-import { SSRProvider } from 'react-bootstrap';
+
 import { ConanKitchenHeader } from '../components/header';
 import ConanFooter from '../components/footer';
 
@@ -507,7 +507,7 @@ function TribePage() {
 
   return (
     <React.StrictMode>
-      <SSRProvider>
+
       <div className="flex-wrapper">
         <ConanKitchenHeader/>
         <section id="tribrsHero" className="py-5 tribes-hero bg-cover bg-center">
@@ -550,7 +550,7 @@ function TribePage() {
         </section>
         <ConanFooter/>
       </div>
-      </SSRProvider>
+
     </React.StrictMode>
   );
 }

--- a/conanio/pages/user-stories.js
+++ b/conanio/pages/user-stories.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { SSRProvider } from 'react-bootstrap';
+
 import { ConanKitchenHeader } from '../components/header';
 import ConanFooter from '../components/footer';
 import Link from 'next/link'
@@ -52,7 +52,7 @@ function UserStoriesPage() {
 
   return (
     <React.StrictMode>
-      <SSRProvider>
+
       <div className="flex-wrapper">
         <ConanKitchenHeader/>
         <section className="user-stories-section py-2">
@@ -63,7 +63,7 @@ function UserStoriesPage() {
         </section>
         <ConanFooter/>
       </div>
-      </SSRProvider>
+
     </React.StrictMode>
   );
 }

--- a/conanio/pages/user-stories/rti.js
+++ b/conanio/pages/user-stories/rti.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { SSRProvider } from 'react-bootstrap';
+
 import { ConanKitchenHeader } from '../../components/header';
 import ConanFooter from '../../components/footer';
 import SingleUserStory from '../../components/user-story';
@@ -7,7 +7,7 @@ import SingleUserStory from '../../components/user-story';
 function UserStoriesRTIPage() {
   return (
     <React.StrictMode>
-      <SSRProvider>
+
       <div className="flex-wrapper">
         <ConanKitchenHeader/>
         <SingleUserStory
@@ -66,7 +66,7 @@ function UserStoriesRTIPage() {
         />
         <ConanFooter/>
       </div>
-      </SSRProvider>
+
     </React.StrictMode>
   );
 }

--- a/conanio/pages/user-stories/tomtom.js
+++ b/conanio/pages/user-stories/tomtom.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { SSRProvider } from 'react-bootstrap';
+
 import { ConanKitchenHeader } from '../../components/header';
 import ConanFooter from '../../components/footer';
 import SingleUserStory from '../../components/user-story';
@@ -8,7 +8,7 @@ import Link from 'next/link'
 function UserStoriesTomtomPage() {
   return (
     <React.StrictMode>
-      <SSRProvider>
+
       <div className="flex-wrapper">
         <ConanKitchenHeader/>
         <SingleUserStory
@@ -147,7 +147,7 @@ function UserStoriesTomtomPage() {
         />
         <ConanFooter/>
       </div>
-      </SSRProvider>
+
     </React.StrictMode>
   );
 }

--- a/conanio/pages/why-conan.js
+++ b/conanio/pages/why-conan.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { useState, useEffect } from "react";
-import { SSRProvider } from 'react-bootstrap';
+
 import Container from 'react-bootstrap/Container';
 import Row from 'react-bootstrap/Row';
 import Col from 'react-bootstrap/Col';
@@ -32,7 +32,7 @@ import Card from 'react-bootstrap/Card';
 function WhyConan() {
   return (
     <React.StrictMode>
-      <SSRProvider>
+
       <div className="flex-wrapper">
         <ConanKitchenHeader/>
         <img src="/conan-cubes.svg" className="d-none d-lg-block position-absolute hero-bg" alt="Conan C++ Package Manager"></img>
@@ -306,7 +306,7 @@ function WhyConan() {
         <br/>
         <ConanFooter/>
       </div>
-      </SSRProvider>
+
     </React.StrictMode>
   );
 }

--- a/conanio/styles/stylev2.css
+++ b/conanio/styles/stylev2.css
@@ -439,7 +439,7 @@ h4, .h4 {
 }
 
 .tab-content>.active {
-  padding: 0px 15px 15px 15px;
+  padding: 15px;
   border-bottom: 1px solid #21AFFF;
   border-left: 1px solid #21AFFF;
   border-right: 1px solid #21AFFF;


### PR DESCRIPTION
Added:
* Search bar automatically gets the cursor within the text area when `conan/center/` or wherever the search bar is loaded.
* "Use it" section: conanfile.txt and conanfile.py tabs are available. Closes: https://github.com/conan-io/web/issues/119

Modified:
* Removed some useless imports.
* Removed SSRProvider. It seems it's not needed anymore for React >= 18: https://react-spectrum.adobe.com/react-aria/ssr.html#react--18
* gtm ID and URL put as env variables.
* Showing `[tool_requires]` or `[requires]` in `Install` global section.