### PR TITLE
Update Artifactory CE URLs

### DIFF
--- a/conanio/pages/downloads.js
+++ b/conanio/pages/downloads.js
@@ -358,10 +358,10 @@ function DownloadJFrogArtifactoryCommunityEditionForCpp() {
                 imageAlt="Docker"
                 imageSrc="/downloads/docker-small-pack.svg"
                 textToShow="$ docker run ..."
-                textToCopy={'docker run --name artifactory -d -p 8081:8081 -p 8082:8082 docker.bintray.io/jfrog/artifactory-cpp-ce:latest'}
+                textToCopy={'docker run --name artifactory -d -p 8081:8081 -p 8082:8082 releases-docker.jfrog.io/jfrog/artifactory-cpp-ce:latest'}
                 gtmProduct={gtmProduct}
                 gtmPlatforms="docker"
-                gtmCopyDescription={'docker run --name artifactory -d -p 8081:8081 -p 8082:8082 docker.bintray.io/jfrog/artifactory-cpp-ce:latest'}
+                gtmCopyDescription={'docker run --name artifactory -d -p 8081:8081 -p 8082:8082 releases-docker.jfrog.io/jfrog/artifactory-cpp-ce:latest'}
               />
               <DownloadInstaller
                 imageAlt="Darwin"


### PR DESCRIPTION
While the bintray.io domain still works, it is not the current domain. I have extracted the new one from the .env file of the following download:

https://releases.jfrog.io/artifactory/bintray-artifactory/org/artifactory/cpp/ce/docker/jfrog-artifactory-cpp-ce/7.63.12/jfrog-artifactory-cpp-ce-7.63.12-compose.tar.gz

This is the counter part to https://github.com/conan-io/docs/pull/3708