### PR TITLE
Fix search debouce timer

### DIFF
--- a/conanio/pages/center/recipes.js
+++ b/conanio/pages/center/recipes.js
@@ -223,17 +223,17 @@ export default function ConanSearch(props) {
         query: {value: value, topics: topiclist, licenses: licenseList}
       }, undefined, {shallow: true})
   }
-
+  let timerId = null;
   const handleChange = (e) => {
     const typingSearch = (v) => {
       getData(v, topics, licenses);
     };
     setValue(e);
-    clearTimeout(timer);
-    const newTimer = setTimeout(() => {
+    clearTimeout(timerId);
+    timerId = setTimeout(() => {
       typingSearch(e);
     }, 500);
-    setTimer(newTimer);
+    setTimer(timerId);
   }
 
   var handleTopics = (selectedOption) => {


### PR DESCRIPTION
We were clearing an nonexistent timer id, so the function was never properly cancelled, resulting in some weird graphical glitchess when typing too fast.

Note that calling `clearTimeout(null)` is ok ([As per mdn](https://developer.mozilla.org/en-US/docs/Web/API/clearTimeout#notes))