### PR TITLE
Fix wrong z-index for background cubes

### DIFF
--- a/conanio/styles/stylev2.css
+++ b/conanio/styles/stylev2.css
@@ -572,6 +572,7 @@ section#faqQuestions {
 .hero-bg {
   top: 422px;
   left: 0;
+  z-index: -1;
 }
 .hero-bg.downloads-hero-bg {
   top: 150px;


### PR DESCRIPTION
Fixes bad z-index for the cubes, most visible in the download section
Before:
![image](https://github.com/conan-io/web/assets/5364255/a9efc309-2acc-4dda-a30c-72635ad33b64)


After:
![image](https://github.com/conan-io/web/assets/5364255/fadc640c-311f-4dce-ad62-43d761655c65)
