### PR TITLE
Avoid 500 errors on unknow versions

### DIFF
--- a/conanio/pages/center/recipes/[recipeName].tsx
+++ b/conanio/pages/center/recipes/[recipeName].tsx
@@ -83,7 +83,7 @@ const ConanPackage: NextPage<PageProps> = (props) => {
 
   useEffect(() => {hljs.highlightAll();});
 
-  let [selectedVersion, setSelectedVersion] = useState(props.recipeVersion !== null? props.recipeVersion: props.data[0].info.version);
+  const [selectedVersion, setSelectedVersion] = useState(props.recipeVersion !== null? props.recipeVersion: props.data[0].info.version);
   let indexSelectedVersion = Object.keys(props.data).filter(index => props.data[index].info.version === selectedVersion)[0];
   if (indexSelectedVersion == null) {
       indexSelectedVersion = "0";

--- a/conanio/pages/center/recipes/[recipeName].tsx
+++ b/conanio/pages/center/recipes/[recipeName].tsx
@@ -83,8 +83,12 @@ const ConanPackage: NextPage<PageProps> = (props) => {
 
   useEffect(() => {hljs.highlightAll();});
 
-  const [selectedVersion, setSelectedVersion] = useState(props.recipeVersion !== null? props.recipeVersion: props.data[0].info.version);
-  const indexSelectedVersion = Object.keys(props.data).filter(index => props.data[index].info.version === selectedVersion)[0];
+  let [selectedVersion, setSelectedVersion] = useState(props.recipeVersion !== null? props.recipeVersion: props.data[0].info.version);
+  let indexSelectedVersion = Object.keys(props.data).filter(index => props.data[index].info.version === selectedVersion)[0];
+  if (indexSelectedVersion == null) {
+      indexSelectedVersion = "0";
+      selectedVersion = props.data[0].info.version;
+  }
   const isTabletOrMobile = useMediaQuery({ query: '(max-width: 1224px)' })
   const [selectedTab, setSelectedTab] = useState(indexSelectedVersion && props.data[indexSelectedVersion].info.status === "ok"? 'use_it': 'versions');
   const [packageOS, setPackageOS] = useState(null);

--- a/conanio/pages/center/recipes/[recipeName].tsx
+++ b/conanio/pages/center/recipes/[recipeName].tsx
@@ -87,7 +87,7 @@ const ConanPackage: NextPage<PageProps> = (props) => {
   let indexSelectedVersion = Object.keys(props.data).filter(index => props.data[index].info.version === selectedVersion)[0];
   if (indexSelectedVersion == null) {
       indexSelectedVersion = "0";
-      selectedVersion = props.data[0].info.version;
+      setSelectedVersion(props.data[0].info.version);
   }
   const isTabletOrMobile = useMediaQuery({ query: '(max-width: 1224px)' })
   const [selectedTab, setSelectedTab] = useState(indexSelectedVersion && props.data[indexSelectedVersion].info.status === "ok"? 'use_it': 'versions');


### PR DESCRIPTION
This would solve `WNC-20237597` 500 warnings as they are not re-checked for discoverability once they are triggered.

