### PR TITLE
Fix: Fix title text 'for C and C++' with nowrap

### DIFF
--- a/conanio/components/home.tsx
+++ b/conanio/components/home.tsx
@@ -21,7 +21,7 @@ const ConanHomeHero = () => (
         <div className="col-6">
           <div className="hero-content py-3">
             <h1 className="black">
-              Conan, software package manager for C and C++ developers
+              Conan, software package manager <span style={{ whiteSpace: "nowrap" }}>for C and C++</span> developers
             </h1>
             <h2 className="homepage-hero-paragraph my-3 black">
               The open source, decentralized and multi-platform package{" "}


### PR DESCRIPTION
On full-screen this was shown as

<img width="1490" height="835" alt="image" src="https://github.com/user-attachments/assets/78a286b6-fb82-470f-a73c-8b586e4a10a6" />
